### PR TITLE
Install packages with rattler

### DIFF
--- a/dof/_src/checkpoint.py
+++ b/dof/_src/checkpoint.py
@@ -94,8 +94,8 @@ class Checkpoint():
     def list_packages(self):
         return self.env_checkpoint.environment.packages
 
-    async def install(self):
-        # WARNING: DOES NOT WORK FOR PIP
+    async def install_with_rattler(self):
+        # WARNING: DOES NOT WORK FOR PIP OR IF YOU HAVE PIP PACKAGES IN YOUR ENV
         repodata_records = [pkg.to_repodata_record() for pkg in self.env_checkpoint.environment.packages]
         repodata_records = [pkg for pkg in repodata_records if pkg is not None]
         await rattler_install(repodata_records, target_prefix=self.prefix)

--- a/dof/_src/checkpoint.py
+++ b/dof/_src/checkpoint.py
@@ -16,6 +16,7 @@ class Checkpoint():
         channels = set()
         for prefix_record in PrefixData(prefix, pip_interop_enabled=True).iter_records_sorted():
             if prefix_record.subdir == "pypi":
+                # import pdb; pdb.set_trace()
                 packages.append(
                     package.PipPackage(
                         name=prefix_record.name,
@@ -83,11 +84,8 @@ class Checkpoint():
         target_packages = target_checkpoint.environment.packages
         current_packages = self.env_checkpoint.environment.packages
 
-        # BIG HACK: this only works because CondaPackages and PipPackages both have url fields
-        target_package_urls = [pkg.url for pkg in target_packages]
-        current_package_urls = [pkg.url for pkg in current_packages]
-        packages_in_current_not_in_target = [item for item in current_packages if item.url not in target_package_urls]
-        packages_in_target_not_in_current = [item for item in target_packages if item.url not in current_package_urls]
+        packages_in_current_not_in_target = [item for item in current_packages if item not in target_packages]
+        packages_in_target_not_in_current = [item for item in target_packages if item not in current_packages]
 
         return packages_in_current_not_in_target, packages_in_target_not_in_current
 

--- a/dof/_src/checkpoint.py
+++ b/dof/_src/checkpoint.py
@@ -1,8 +1,10 @@
 from typing import List, Dict
 import datetime
+import asyncio
 
 from conda.core.prefix_data import PrefixData
 from rattler import Platform
+from rattler import install as rattler_install
 
 from dof._src.models import package, environment
 from dof._src.utils import hash_string
@@ -35,7 +37,8 @@ class Checkpoint():
                         conda_channel=prefix_record.channel.url(),
                         # TODO
                         arch="",
-                        platform="",
+                        # not sure here
+                        platform="linux-64",
                         url=prefix_record.url
                     )
                 )
@@ -90,3 +93,9 @@ class Checkpoint():
 
     def list_packages(self):
         return self.env_checkpoint.environment.packages
+
+    async def install(self):
+        # WARNING: DOES NOT WORK FOR PIP
+        repodata_records = [pkg.to_repodata_record() for pkg in self.env_checkpoint.environment.packages]
+        repodata_records = [pkg for pkg in repodata_records if pkg is not None]
+        await rattler_install(repodata_records, target_prefix=self.prefix)

--- a/dof/_src/checkpoint.py
+++ b/dof/_src/checkpoint.py
@@ -26,7 +26,7 @@ class Checkpoint():
             else:
                 channels.add(prefix_record.channel.name)
                 packages.append(
-                    package.UrlPackage(url=prefix_record.url)
+                    package.UrlCondaPackage(url=prefix_record.url)
                 )
 
         env_metadata = environment.EnvironmentMetadata(

--- a/dof/_src/checkpoint.py
+++ b/dof/_src/checkpoint.py
@@ -26,7 +26,18 @@ class Checkpoint():
             else:
                 channels.add(prefix_record.channel.name)
                 packages.append(
-                    package.UrlCondaPackage(url=prefix_record.url)
+                    package.CondaPackage(
+                        name=prefix_record.name,
+                        version=prefix_record.version,
+                        build=prefix_record.build,
+                        build_number=prefix_record.build_number,
+                        subdir=prefix_record.subdir,
+                        conda_channel=prefix_record.channel.url(),
+                        # TODO
+                        arch="",
+                        platform="",
+                        url=prefix_record.url
+                    )
                 )
 
         env_metadata = environment.EnvironmentMetadata(
@@ -72,8 +83,12 @@ class Checkpoint():
         target_packages = target_checkpoint.environment.packages
         current_packages = self.env_checkpoint.environment.packages
 
-        packages_in_current_not_in_target = [item for item in current_packages if item not in target_packages]
-        packages_in_target_not_in_current = [item for item in target_packages if item not in current_packages]
+        # BIG HACK: this only works because CondaPackages and PipPackages both have url fields
+        target_package_urls = [pkg.url for pkg in target_packages]
+        current_package_urls = [pkg.url for pkg in current_packages]
+        packages_in_current_not_in_target = [item for item in current_packages if item.url not in target_package_urls]
+        packages_in_target_not_in_current = [item for item in target_packages if item.url not in current_package_urls]
+
         return packages_in_current_not_in_target, packages_in_target_not_in_current
 
     def list_packages(self):

--- a/dof/_src/checkpoint.py
+++ b/dof/_src/checkpoint.py
@@ -16,7 +16,6 @@ class Checkpoint():
         channels = set()
         for prefix_record in PrefixData(prefix, pip_interop_enabled=True).iter_records_sorted():
             if prefix_record.subdir == "pypi":
-                # import pdb; pdb.set_trace()
                 packages.append(
                     package.PipPackage(
                         name=prefix_record.name,

--- a/dof/_src/lock.py
+++ b/dof/_src/lock.py
@@ -10,6 +10,7 @@ from dof._src.models.package import UrlCondaPackage
 from dof._src.utils import hash_string
 
 
+# TODO: don't use this
 def lock_environment(path: str, target_platform: str | None = None) -> EnvironmentSpec:
     lock_spec =  _parse_environment_file(path)
 

--- a/dof/_src/lock.py
+++ b/dof/_src/lock.py
@@ -6,7 +6,7 @@ from typing import List
 from rattler import solve, Platform
 
 from dof._src.models.environment import CondaEnvironmentSpec, EnvironmentSpec, EnvironmentMetadata
-from dof._src.models.package import UrlPackage
+from dof._src.models.package import UrlCondaPackage
 from dof._src.utils import hash_string
 
 
@@ -22,7 +22,7 @@ def lock_environment(path: str, target_platform: str | None = None) -> Environme
 
     url_packages = []
     for pkg in solution_packages:
-        url_packages.append(UrlPackage(url = pkg.url))
+        url_packages.append(UrlCondaPackage(url = pkg.url))
 
     env_metadata = EnvironmentMetadata(
         platform = str(target_platform),

--- a/dof/_src/models/package.py
+++ b/dof/_src/models/package.py
@@ -25,7 +25,9 @@ class CondaPackage(BaseModel):
         return f"conda: {self.name} - {self.version}"
     
     def __eq__(self, other):
-        return self.url == other.url
+        if isinstance(other, CondaPackage):
+            return self.url == other.url
+        return False
 
 
 class PipPackage(BaseModel):
@@ -36,6 +38,11 @@ class PipPackage(BaseModel):
 
     def __str__(self):
         return f"pip: {self.name} - {self.version}"
+    
+    def __eq__(self, other):
+        if isinstance(other, PipPackage):
+            return self.name == other.name and self.version == other.version and self.build == other.build
+        return False
 
 
 class UrlCondaPackage(BaseModel):

--- a/dof/_src/models/package.py
+++ b/dof/_src/models/package.py
@@ -19,8 +19,8 @@ class CondaPackage(BaseModel):
         """Converts a url package into a rattler compatible repodata record."""
         pkg_record = PackageRecord(
              name=self.name, version=self.version, build=self.build,
-             build_number=self.build_number, subdir=self.subdir, arch=self.arch,
-             platform=self.platform
+             build_number=self.build_number, subdir=self.subdir, arch=None,
+             platform=None
         )
         return RepoDataRecord(
             package_record=pkg_record,
@@ -55,7 +55,8 @@ class PipPackage(BaseModel):
     
     def to_repodata_record(self):
         """Converts a url package into a rattler compatible repodata record."""
-        return
+        # no-op
+        pass
 
 
 class UrlCondaPackage(BaseModel):

--- a/dof/_src/models/package.py
+++ b/dof/_src/models/package.py
@@ -7,7 +7,7 @@ class CondaPackage(BaseModel):
     name: str
     version: str
     build: str
-    build_number: str
+    build_number: int
     subdir: str
     # must be the full url of the channel, eg. 'https://conda.anaconda.org/conda-forge/win-64'
     conda_channel: str
@@ -17,7 +17,15 @@ class CondaPackage(BaseModel):
 
     def to_repodata_record(self):
         """Converts a url package into a rattler compatible repodata record."""
+        #  pr = PackageRecord(name="test-package", version="0.1", build="0", build_number=0, subdir="linux", arch="noarch", platform="linux-64")
+        #  RepoDataRecord(package_record=pr, file_name="test-package-0.1-0.tar.bz2", channel="https://conda.anaconda.org/conda-forge/win-64", url="https://conda.anaconda.org/test/noarch/test-package-0.1-0.tar.bz2")
         pass
+
+    def __str__(self):
+        return f"conda: {self.name} - {self.version}"
+    
+    def __eq__(self, other):
+        return self.url == other.url
 
 
 class PipPackage(BaseModel):

--- a/dof/_src/models/package.py
+++ b/dof/_src/models/package.py
@@ -1,5 +1,5 @@
 from typing import Dict, Union, Optional
-from rattler import RepoDataRecord
+from rattler import RepoDataRecord, PackageRecord
 from pydantic import BaseModel
 
 
@@ -17,9 +17,18 @@ class CondaPackage(BaseModel):
 
     def to_repodata_record(self):
         """Converts a url package into a rattler compatible repodata record."""
-        #  pr = PackageRecord(name="test-package", version="0.1", build="0", build_number=0, subdir="linux", arch="noarch", platform="linux-64")
-        #  RepoDataRecord(package_record=pr, file_name="test-package-0.1-0.tar.bz2", channel="https://conda.anaconda.org/conda-forge/win-64", url="https://conda.anaconda.org/test/noarch/test-package-0.1-0.tar.bz2")
-        pass
+        pkg_record = PackageRecord(
+             name=self.name, version=self.version, build=self.build,
+             build_number=self.build_number, subdir=self.subdir, arch=self.arch,
+             platform=self.platform
+        )
+        return RepoDataRecord(
+            package_record=pkg_record,
+            file_name=self.url.split("/")[-1],
+            channel=self.conda_channel,
+            url=self.url
+        )
+        
 
     def __str__(self):
         return f"conda: {self.name} - {self.version}"
@@ -43,6 +52,10 @@ class PipPackage(BaseModel):
         if isinstance(other, PipPackage):
             return self.name == other.name and self.version == other.version and self.build == other.build
         return False
+    
+    def to_repodata_record(self):
+        """Converts a url package into a rattler compatible repodata record."""
+        return
 
 
 class UrlCondaPackage(BaseModel):

--- a/dof/_src/models/package.py
+++ b/dof/_src/models/package.py
@@ -1,5 +1,5 @@
 from typing import Dict, Union, Optional
-
+from rattler import RepoDataRecord
 from pydantic import BaseModel
 
 
@@ -7,9 +7,17 @@ class CondaPackage(BaseModel):
     name: str
     version: str
     build: str
-    platform: str
+    build_number: str
+    subdir: str
+    # must be the full url of the channel, eg. 'https://conda.anaconda.org/conda-forge/win-64'
     conda_channel: str
-    hash: Dict[str, str]
+    arch: str
+    platform: str
+    url: str
+
+    def to_repodata_record(self):
+        """Converts a url package into a rattler compatible repodata record."""
+        pass
 
 
 class PipPackage(BaseModel):
@@ -22,7 +30,7 @@ class PipPackage(BaseModel):
         return f"pip: {self.name} - {self.version}"
 
 
-class UrlPackage(BaseModel):
+class UrlCondaPackage(BaseModel):
     url: str
 
     def __str__(self):
@@ -32,4 +40,4 @@ class UrlPackage(BaseModel):
         return f"conda: {name} - {version}"
 
 
-Package = Union[CondaPackage, PipPackage, UrlPackage]
+Package = Union[CondaPackage, PipPackage, UrlCondaPackage]

--- a/dof/cli/checkpoint.py
+++ b/dof/cli/checkpoint.py
@@ -94,7 +94,7 @@ def install(
     for pkg in packages_in_target_not_in_current:
         print(f"+ {pkg}")
 
-    asyncio.run(chck.install())
+    print("Opps, I actually don't know how to install. Skipping for now!")
 
 
 @checkpoint_command.command()

--- a/dof/cli/checkpoint.py
+++ b/dof/cli/checkpoint.py
@@ -93,6 +93,10 @@ def install(
     for pkg in packages_in_target_not_in_current:
         print(f"+ {pkg}")
 
+    # WARNING: DOES NOT WORK FOR PIP
+    repodata_records = [pkg.to_repodata_record() for pkg in packages_in_target_not_in_current]
+    print(f"passing repodata records to rattler install: {repodata_records}")
+
 
 @checkpoint_command.command()
 def diff(

--- a/dof/cli/checkpoint.py
+++ b/dof/cli/checkpoint.py
@@ -1,10 +1,11 @@
 import os
 import typer
 from typing import List
+import asyncio
+
 from rich.table import Table
 import rich
 
-from dof._src.models.environment import EnvironmentCheckpoint
 from dof._src.checkpoint import Checkpoint
 from dof._src.data.local import LocalData
 from dof._src.utils import short_uuid
@@ -93,9 +94,7 @@ def install(
     for pkg in packages_in_target_not_in_current:
         print(f"+ {pkg}")
 
-    # WARNING: DOES NOT WORK FOR PIP
-    repodata_records = [pkg.to_repodata_record() for pkg in packages_in_target_not_in_current]
-    print(f"passing repodata records to rattler install: {repodata_records}")
+    asyncio.run(chck.install())
 
 
 @checkpoint_command.command()

--- a/dof/cli/checkpoint.py
+++ b/dof/cli/checkpoint.py
@@ -81,7 +81,17 @@ def install(
     ),
 ):
     """Install a previous revision of the environment"""
-    print("not installing")
+    prefix = os.environ.get("CONDA_PREFIX")
+    env_uuid = short_uuid()
+    chck = Checkpoint.from_prefix(prefix=prefix, uuid=env_uuid)
+    packages_in_current_not_in_target, packages_in_target_not_in_current = chck.diff(rev)
+
+    print("packages to delete")
+    for pkg in packages_in_current_not_in_target:
+        print(f"- {pkg}")
+    print("\npackages to install")
+    for pkg in packages_in_target_not_in_current:
+        print(f"+ {pkg}")
 
 
 @checkpoint_command.command()

--- a/dof/cli/root.py
+++ b/dof/cli/root.py
@@ -97,6 +97,5 @@ def pull(
     checkpoint_dict = yaml.load(checkpoint_data, yaml.FullLoader)
 
     prefix = os.environ.get("CONDA_PREFIX")
-    # import pdb; pdb.set_trace()
     chck = Checkpoint.from_checkpoint_dict(checkpoint_data=checkpoint_dict, prefix=prefix)
     chck.save()


### PR DESCRIPTION
This adds the ability to install a revision with rattler but does not expose this functionality to the user.

Currently, only conda packages are supported. So, trying to change an environment with pip packages will result in breaking the environment. 

Note, if you are installing dof locally with pip, this will break your dof and/or conda.